### PR TITLE
Adapt navbar to dark mode

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,18 +1,18 @@
 navbar:
-  right:
-  - icon: fa-users
-    href: https://ropengov.org
-  - icon: fab fa-github
-    href: https://github.com/rOpenGov/kelaopendata
-  left:
-  - text: Reference
-    href: reference/index.html
-  - text: Articles
-    menu:
-    - text: Fetching data using kelaopendata
-      href: articles/read_data.html
-    - text: Read dataset from original csv files using kelaopendata
-      href: articles/read_data_csv.html
+  structure:
+    right: [search, users, github, lightswitch]
+  components:
+    users:
+      icon: fa-users
+      href: https://ropengov.org
+      aria-label: rOpenGov
+    articles:
+      text: Articles
+      menu:
+      - text: Fetching data using kelaopendata
+        href: articles/read_data.html
+      - text: Read dataset from original csv files using kelaopendata
+        href: articles/read_data_csv.html
 url: https://ropengov.github.io/kelaopendata/
 template:
   package: rogtemplate

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,13 +6,6 @@ navbar:
       icon: fa-users
       href: https://ropengov.org
       aria-label: rOpenGov
-    articles:
-      text: Articles
-      menu:
-      - text: Fetching data using kelaopendata
-        href: articles/read_data.html
-      - text: Read dataset from original csv files using kelaopendata
-        href: articles/read_data_csv.html
 url: https://ropengov.github.io/kelaopendata/
 template:
   package: rogtemplate


### PR DESCRIPTION
Fix #4 (see as reference also for https://github.com/rOpenGov/geofi/issues/57)

This is safer, as less default components are modified:

> Note that customising `navbar` like this comes with a downside: if pkgdown later changes 
> the defaults, you’ll have to update your `_pkgdown.yml.` 
>
> https://pkgdown.r-lib.org/articles/customise.html#navbar-heading

Some settings were not needed as they replicated the default behaviour of **pkgdown** BS5 (e.g. Reference, Articles, GitHub).

The final look is:


<img width="1920" height="826" alt="kelaopendata_dark2" src="https://github.com/user-attachments/assets/fb4509e6-a7f8-4c80-a6ed-01ad2372da81" />
